### PR TITLE
Fixed issue with \n in toTokenList

### DIFF
--- a/src/commonMain/kotlin/dev/snipme/highlights/internal/SyntaxTokens.kt
+++ b/src/commonMain/kotlin/dev/snipme/highlights/internal/SyntaxTokens.kt
@@ -145,6 +145,6 @@ internal object SyntaxTokens {
     val PUNCTUATION_CHARACTERS = listOf(",", ".", ":", ";")
     val MARK_CHARACTERS = listOf("(", ")", "=", "{", "}", "<", ">", "-", "+", "[", "]", "|", "&")
 
-    private fun String.toTokenList() = trimIndent().split(",").toSet()
+    private fun String.toTokenList() = trimIndent().split("[\\s,]+".toRegex()).toSet()
 }
 


### PR DESCRIPTION
The `SyntaxTokens.toTokenList` function had an edge case where some tokens were not being recognized properly. This was due to `\n` characters creeping into the list. This fixes that.

![image](https://github.com/SnipMeDev/Highlights/assets/698270/c7dcfaf4-cde5-43a2-91a6-579b8991370c)
